### PR TITLE
fix: Adds repo missing function

### DIFF
--- a/contracts/RiteOfMoloch.sol
+++ b/contracts/RiteOfMoloch.sol
@@ -263,6 +263,15 @@ contract RiteOfMoloch is InitializationData, ERC721Upgradeable, AccessControlUpg
         emit ChangedShares(newShareThreshold);
     }
 
+    /**
+     * @dev Allows changing the base URI
+     * @param newBaseURI the new base URI
+     */
+    function setBaseURI(string calldata newBaseURI) public onlyRole(ADMIN) {
+        _setBaseUri(newBaseURI);
+    }
+
+
     /*************************
      PRIVATE OR INTERNAL
      *************************/


### PR DESCRIPTION
`function setBaseURI(string calldata newBaseURI) public onlyRole(ADMIN)` <br>
exists on chain at deployed and verified instance, but not in repo.

Fixes discrepancy between what is deployed and this repository.